### PR TITLE
Dynamic input thread loading

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -4,6 +4,21 @@ Key:
 = : Change / Fix
 + : Added feature
 
+0.0.8 - 1st May 2016
++ Added memory management for profile Input Threads
+  The "Input Threads" which handle detection of input (one for each profile)...
+  ... now start and stop dynamically as profiles change.
+  This is to limit the amount of memory UCR uses to a reasonable level.
+  A Profile's Input Thread will now be unloaded on profile change if they are a ...
+  ... "Linked Profile" of the new profile or the global profile.
+  Profile A is considered a "Linked Profile" of Profile B if eg...
+  ... a Profile Switcher plugin in Profile B is configured to point to Profile A.
+  Plugins can call UpdateLinkedProfiles() on the parent Profile...
+  ... to set their relationship to other Profiles (Add or remove a link).
+= All debug output now prefixed with UCR|
+  So if using DebugView, you can just filter for only UCR stuff using the string:
+  DBGVIEWCLEAR;UCR|*
+
 0.0.7 - 13th Mar 2016
 ! Warning! Settings version has changed.
   BACK UP your INI file before using it with this version, if you value it.

--- a/Plugins/Core/ProfileSwitcher.ahk
+++ b/Plugins/Core/ProfileSwitcher.ahk
@@ -51,11 +51,14 @@ class ProfileSwitcher extends _Plugin {
 	
 	; Called when the currently selected profile changes
 	UpdateCurrentProfile(id){
-		OutputDebug % "UCR| Profile change called on plugin. old: " this.GuiControls.ProfileID.value ", new: " id
+		;OutputDebug % "UCR| Profile change called on plugin. old: " this.GuiControls.ProfileID.value ", new: " id
+		; Update profile's list of "Linked" profiles...
+		; .. these are the profiles that this profile may need to switch to quickly...
+		; ... so they need to be kept in memory.
 		this.ParentProfile.UpdateLinkedProfiles(this.name, this.GuiControls.ProfileID.value, 0)
 		this.ParentProfile.UpdateLinkedProfiles(this.name, id, 1)
+		; Update readout GuiControl
 		GuiControl, , % this.hCurrentProfile, % UCR.BuildProfilePathName(id)
-		;GuiControl, , % this.GuiControls.ProfileID.hwnd, % id
 	}
 	
 	; The hotkey was pressed to change profile

--- a/Plugins/Core/ProfileSwitcher.ahk
+++ b/Plugins/Core/ProfileSwitcher.ahk
@@ -49,8 +49,11 @@ class ProfileSwitcher extends _Plugin {
 		this.GuiControls.ProfileID.value := id
 	}
 	
-	; Updates the GuiControl that displays the current profile
+	; Called when the currently selected profile changes
 	UpdateCurrentProfile(id){
+		OutputDebug % "UCR| Profile change called on plugin. old: " this.GuiControls.ProfileID.value ", new: " id
+		this.ParentProfile.UpdateLinkedProfiles(this.name, this.GuiControls.ProfileID.value, 0)
+		this.ParentProfile.UpdateLinkedProfiles(this.name, id, 1)
 		GuiControl, , % this.hCurrentProfile, % UCR.BuildProfilePathName(id)
 		;GuiControl, , % this.GuiControls.ProfileID.hwnd, % id
 	}
@@ -62,6 +65,10 @@ class ProfileSwitcher extends _Plugin {
 			if !(UCR.ChangeProfile(this.GuiControls.ProfileID.value))
 				SoundBeep, 300, 200
 		}
+	}
+	
+	OnDelete(){
+		this.ParentProfile.UpdateLinkedProfiles(this.name, this.GuiControls.ProfileID.value, 0)
 	}
 	
 	; In order to free memory when a plugin is closed, we must free references to this object

--- a/Threads/ProfileInputThread.ahk
+++ b/Threads/ProfileInputThread.ahk
@@ -20,7 +20,9 @@ class _InputThread {
 	PovMap := [[0,0,0,0], [1,0,0,0], [1,1,0,0] , [0,1,0,0], [0,1,1,0], [0,0,1,0], [0,0,1,1], [0,0,0,1], [1,0,0,1]]
 	MouseDeltaMappings := {}
 	
-	__New(CallbackPtr){
+	__New(Profile, CallbackPtr){
+		OutputDebug, % "UCR| InputThread for ProfileID #" ProfileID " starting"
+		this.ProfileID := Profile ; Profile ID of parent profile. So we know which profile this thread serves
 		this.Callback := ObjShare(CallbackPtr)
 		Gui, +HwndHwnd		; Get a unique hwnd so we can register for messages
 		this.hwnd := hwnd
@@ -34,6 +36,7 @@ class _InputThread {
 		global _InterfaceSetAxisBinding := ObjShare(this.SetAxisBinding.Bind(this))
 		global _InterfaceSetDeltaBinding := ObjShare(this.SetDeltaBinding.Bind(this))
 		this.SetHotkeyState(0)
+		OutputDebug, % "UCR| InputThread for ProfileID #" this.ProfileID " is ready to accept bindings"
 	}
 	
 	; All input flows from here back to the main thread

--- a/Threads/ProfileInputThread.ahk
+++ b/Threads/ProfileInputThread.ahk
@@ -20,9 +20,9 @@ class _InputThread {
 	PovMap := [[0,0,0,0], [1,0,0,0], [1,1,0,0] , [0,1,0,0], [0,1,1,0], [0,0,1,0], [0,0,1,1], [0,0,0,1], [1,0,0,1]]
 	MouseDeltaMappings := {}
 	
-	__New(Profile, CallbackPtr){
-		OutputDebug, % "UCR| InputThread for ProfileID #" Profile " starting"
-		this.ProfileID := Profile ; Profile ID of parent profile. So we know which profile this thread serves
+	__New(ProfileID, CallbackPtr){
+		;OutputDebug, % "UCR|InputThread #" ProfileID "| Ctor: Thread is starting"
+		this.ProfileID := ProfileID ; Profile ID of parent profile. So we know which profile this thread serves
 		this.Callback := ObjShare(CallbackPtr)
 		Gui, +HwndHwnd		; Get a unique hwnd so we can register for messages
 		this.hwnd := hwnd
@@ -36,7 +36,7 @@ class _InputThread {
 		global _InterfaceSetAxisBinding := ObjShare(this.SetAxisBinding.Bind(this))
 		global _InterfaceSetDeltaBinding := ObjShare(this.SetDeltaBinding.Bind(this))
 		this.SetHotkeyState(0)
-		OutputDebug, % "UCR| InputThread for ProfileID #" this.ProfileID " is ready to accept bindings"
+		OutputDebug, % "UCR|InputThread #" this.ProfileID "| Ctor: Thread started"
 	}
 	
 	; All input flows from here back to the main thread

--- a/Threads/ProfileInputThread.ahk
+++ b/Threads/ProfileInputThread.ahk
@@ -21,7 +21,7 @@ class _InputThread {
 	MouseDeltaMappings := {}
 	
 	__New(Profile, CallbackPtr){
-		OutputDebug, % "UCR| InputThread for ProfileID #" ProfileID " starting"
+		OutputDebug, % "UCR| InputThread for ProfileID #" Profile " starting"
 		this.ProfileID := Profile ; Profile ID of parent profile. So we know which profile this thread serves
 		this.Callback := ObjShare(CallbackPtr)
 		Gui, +HwndHwnd		; Get a unique hwnd so we can register for messages

--- a/UCR.ahk
+++ b/UCR.ahk
@@ -183,7 +183,7 @@ Class UCRMain {
 		if (!ObjHasKey(this.Profiles, id))
 			return 0
 		newprofile := this.Profiles[id]
-		OutputDebug % "Changing Profile from " this.CurrentProfile.Name " to: " newprofile.Name
+		OutputDebug % "UCR| Changing Profile from " this.CurrentProfile.Name " to: " newprofile.Name
 		; Check if there is currently an active profile
 		if (IsObject(this.CurrentProfile)){
 			; Do nothing if we are changing to the currently active profile
@@ -324,7 +324,7 @@ Class UCRMain {
 	MoveProfile(profile_id, parent_id, after){
 		if (parent_id == "")
 			parent_id := 0
-		OutputDebug % "UCR.MoveProfile: profile: " profile_id ", parent: " parent_id ", after: " after
+		OutputDebug % "UCR| MoveProfile: profile: " profile_id ", parent: " parent_id ", after: " after
 		; Do not allowing move of default or global profile
 		if (profile_id < 3 || !ObjHasKey(this.Profiles, profile_id))
 			return 0
@@ -473,7 +473,7 @@ Class UCRMain {
 			; Settings file empty or not found, create new settings
 			j := {"CurrentProfile":"2", "SettingsVersion": this.SettingsVersion, "ProfileTree": {0: [1, 2]}, "Profiles":{"1":{"Name": "Global", "ParentProfile": "0"}, "2": {"Name": "Default", "ParentProfile": "0"}}}
 		} else {
-			OutputDebug % "Loading JSON from disk"
+			OutputDebug % "UCR| Loading JSON from disk"
 			j := JSON.Load(j)
 		}
 		
@@ -503,7 +503,7 @@ Class UCRMain {
 		SetTimer, Save, -1000
 		Return
 		Save:
-			OutputDebug % "Saving JSON to disk"
+			OutputDebug % "UCR| Saving JSON to disk"
 			FileReplace(JSON.Dump(obj, ,true), SettingsFile)
 		Return
 
@@ -595,7 +595,7 @@ Class UCRMain {
 	; Bind Mode Ended.
 	; Decide whether or not binding is valid, and if so set binding and re-enable inputs
 	_BindModeEnded(hk, bo){
-		OutputDebug % "Bind Mode Ended: " bo.Buttons[1].code
+		;OutputDebug % "UCR| Bind Mode Ended: " bo.Buttons[1].code
 		this._CurrentState := this._State.Normal
 		if (hk._IsOutput){
 			hk.value := bo
@@ -800,7 +800,7 @@ class _ProfileToolbox extends _ProfileSelect {
 				Else
 					SendMessage_( this.hTreeview, TVM_SETINSERTMARK, fAfter, hitTarget ) ; show insertion mark
 				this.BeforeAfter := fAfter + 1
-				;OutputDebug % "Treeview_Dragging: this.BeforeAfter: " this.BeforeAfter
+				;OutputDebug % "UCR| Treeview_Dragging: this.BeforeAfter: " this.BeforeAfter
 			}
 		}
 		OnMessage( 0x202, this.DragEndFn ) ; WM_LBUTTONUP
@@ -857,7 +857,7 @@ class _ProfileToolbox extends _ProfileSelect {
 							} else {
 								parent := hDroptarget
 							}
-							;OutputDebug % "Treeview_EndDrag: this.BeforeAfter: " this.BeforeAfter
+							;OutputDebug % "UCR| Treeview_EndDrag: this.BeforeAfter: " this.BeforeAfter
 							this.MoveNode(this.hDragitem, parent, after)
 							;~ this.AddNodeToParent( this.hDragitem, parent, after )
 							;~ TV_Modify( hDropTarget, "Expand" )
@@ -1178,7 +1178,7 @@ class _BindModeHandler {
 	
 	; The BindModeThread calls back here
 	_ProcessInput(e, type, code, deviceid){
-		;OutputDebug % "e: " e ", type: " type ", code: " code ", deviceid: " deviceid
+		;OutputDebug % "UCR| _ProcessInput: e: " e ", type: " type ", code: " code ", deviceid: " deviceid
 		; Build Key object and pass to ProcessInput
 		i := new _Button({type: type, code: code, deviceid: deviceid})
 		this.ProcessInput(i,e)
@@ -1278,7 +1278,7 @@ Class _Profile {
 	; Starts the "Input Thread" which handles detection of input for this profile
 	_StartInputThread(){
 		if (this._InputThread == 0){
-			OutputDebug % "Starting Input Thread for thread #" this.id " ( " this.Name " )"
+			OutputDebug % "UCR| Starting Input Thread for thread #" this.id " ( " this.Name " )"
 			FileRead, Script, % A_ScriptDir "\Threads\ProfileInputThread.ahk"
 			this._InputThread := AhkThread("InputThread := new _InputThread(" ObjShare(UCR._InputHandler.InputEvent.Bind(UCR._InputHandler)) ")`n" Script)
 			While !this._InputThread.ahkgetvar.autoexecute_done
@@ -1294,7 +1294,7 @@ Class _Profile {
 	; Stops the "Input Thread" which handles detection of input for this profile
 	_StopInputThread(){
 		if (this._InputThread != 0){
-			OutputDebug % "Stopping Input Thread for thread #" this.id " ( " this.Name " )"
+			OutputDebug % "UCR| Stopping Input Thread for thread #" this.id " ( " this.Name " )"
 			ahkthread_free(this._InputThread)
 			this._InputThread := 0
 		}
@@ -1496,7 +1496,7 @@ Class _Profile {
 	}
 
 	_PluginChanged(plugin){
-		OutputDebug % "Profile " this.Name " --> UCR"
+		OutputDebug % "UCR| Profile " this.Name " calling UCR._ProfileChanged"
 		UCR._ProfileChanged(this)
 	}
 }
@@ -1579,7 +1579,7 @@ Class _Plugin {
 	}
 	
 	__Delete(){
-		OutputDebug % "Plugin " this.name " in profile " this.ParentProfile.name " fired destructor"
+		OutputDebug % "UCR| Plugin " this.name " in profile " this.ParentProfile.name " fired destructor"
 	}
 	
 	; Initialize the GUI
@@ -1611,7 +1611,7 @@ Class _Plugin {
 
 	; A GuiControl / Hotkey changed
 	_ControlChanged(ctrl){
-		OutputDebug % "Plugin " this.Name " --> Profile"
+		OutputDebug % "UCR| Plugin " this.Name " called ParentProfile._PluginChanged()"
 		this.ParentProfile._PluginChanged(this)
 	}
 	
@@ -1739,7 +1739,7 @@ class _GuiControl {
 	}
 	
 	__Delete(){
-		OutputDebug % "GuiControl " this.name " in plugin " this.ParentPlugin.name " fired destructor"
+		OutputDebug % "UCR| GuiControl " this.name " in plugin " this.ParentPlugin.name " fired destructor"
 	}
 	
 	_KillReferences(){
@@ -1770,7 +1770,7 @@ class _GuiControl {
 		; Fire _ControlChanged on parent so new setting can be saved
 		set {
 			this.__value := value
-			OutputDebug % "GuiControl " this.Name " --> Plugin"
+			OutputDebug % "UCR| GuiControl " this.Name " called ParentPlugin._ControlChanged()"
 			this.ParentPlugin._ControlChanged(this)
 		}
 	}
@@ -1921,7 +1921,7 @@ class _InputButton extends _BannerCombo {
 	}
 	
 	__Delete(){
-		OutputDebug % "Hotkey " this.name " in plugin " this.ParentPlugin.name " fired destructor"
+		OutputDebug % "UCR| Hotkey " this.name " in plugin " this.ParentPlugin.name " fired destructor"
 	}
 	
 	; Kill references so destructor can fire
@@ -1938,7 +1938,7 @@ class _InputButton extends _BannerCombo {
 		
 		set {
 			this._value := value	; trigger _value setter to set value and cuebanner etc
-			OutputDebug % "Hotkey " this.Name " --> Plugin"
+			OutputDebug % "UCR| Hotkey " this.Name " called ParentPlugin._ControlChanged()"
 			this.ParentPlugin._ControlChanged(this)
 		}
 	}
@@ -2145,7 +2145,7 @@ class _InputAxis extends _BannerCombo {
 		; Fire _ControlChanged on parent so new setting can be saved
 		set {
 			this._value := value
-			OutputDebug % "GuiControl " this.Name " --> Plugin"
+			OutputDebug % "UCR| GuiControl " this.Name " called ParentPlugin._ControlChanged()"
 			this.ParentPlugin._ControlChanged(this)
 		}
 	}
@@ -2428,7 +2428,7 @@ Class _OutputButton extends _InputButton {
 	}
 	
 	__Delete(){
-		OutputDebug % "Output " this.name " in plugin " this.ParentPlugin.name " fired destructor"
+		OutputDebug % "UCR| Output " this.name " in plugin " this.ParentPlugin.name " fired destructor"
 	}
 	
 	; Kill references so destructor can fire
@@ -2550,7 +2550,7 @@ class _OutputAxis extends _BannerCombo {
 		; Fire _ControlChanged on parent so new setting can be saved
 		set {
 			this._value := value
-			OutputDebug % "GuiControl " this.Name " --> Plugin"
+			OutputDebug % "UCR| GuiControl " this.Name " called ParentPlugin._ControlChanged()"
 			this.ParentPlugin._ControlChanged(this)
 		}
 	}

--- a/UCR.ahk
+++ b/UCR.ahk
@@ -391,8 +391,7 @@ Class UCRMain {
 			}
 		}
 		; Terminate profile input thread
-		ahkthread_free(profile._InputThread)
-		profile._InputThread := ""
+		profile._StopInputThread()
 		; Kill profile object
 		this.profiles.Delete(profile.id)
 	}
@@ -1243,6 +1242,7 @@ Class _Profile {
 	PluginOrder := []
 	AssociatedApss := 0
 	_IsGlobal := 0
+	_InputThread := 0
 	
 	__New(id, name, parent){
 		static fn
@@ -1252,6 +1252,11 @@ Class _Profile {
 		if (this.Name = "global"){
 			this._IsGlobal := 1
 		}
+		this._StartInputThread()
+		this._CreateGui()
+	}
+	
+	_StartInputThread(){
 		FileRead, Script, % A_ScriptDir "\Threads\ProfileInputThread.ahk"
 		this._InputThread := AhkThread("InputThread := new _InputThread(" ObjShare(UCR._InputHandler.InputEvent.Bind(UCR._InputHandler)) ")`n" Script)
 		While !this._InputThread.ahkgetvar.autoexecute_done
@@ -1261,7 +1266,13 @@ Class _Profile {
 		this._SetButtonBinding := ObjShare(this._InputThread.ahkgetvar("_InterfaceSetButtonBinding"))
 		this._SetAxisBinding := ObjShare(this._InputThread.ahkgetvar("_InterfaceSetAxisBinding"))
 		this._SetDeltaBinding := ObjShare(this._InputThread.ahkgetvar("_InterfaceSetDeltaBinding"))
-		this._CreateGui()
+	}
+	
+	_StopInputThread(){
+		if (this._InputThread){
+			ahkthread_free(this._InputThread)
+			this._InputThread := 0
+		}
 	}
 	
 	__Delete(){

--- a/UCR.ahk
+++ b/UCR.ahk
@@ -184,10 +184,10 @@ Class UCRMain {
 	
 	_SetProfileInputThreadState(profile, state){
 		if (state){
-			this._ActiveInputThreads.Delete(profile)	; Remove key entirely for "off"
+			this._ActiveInputThreads[profile] := 1
 			this.Profiles[profile]._StartInputThread()
 		} else {
-			this._ActiveInputThreads[profile] := 1
+			this._ActiveInputThreads.Delete(profile)	; Remove key entirely for "off"
 			this.Profiles[profile]._StopInputThread()
 		}
 	}

--- a/UCR.ahk
+++ b/UCR.ahk
@@ -219,7 +219,6 @@ Class UCRMain {
 					this._SetProfileInputThreadState(profile,0)
 				}
 			}
-			
 		}
 		
 		; Change current profile to new profile
@@ -235,6 +234,13 @@ Class UCRMain {
 		
 		; Make the new profile's Gui visible
 		this.CurrentProfile._Show()
+		
+		; Start the InputThreads for any linked profiles
+		for profile, state in this.CurrentProfile._LinkedProfiles {
+			if (this.Profiles[profile]._InputThread = 0){
+				this._SetProfileInputThreadState(profile,1)
+			}
+		}
 		
 		; Save settings
 		if (save){

--- a/UCR.ahk
+++ b/UCR.ahk
@@ -1333,7 +1333,7 @@ Class _Profile {
 			this._InputThread := AhkThread("InputThread := new _InputThread(" this.id "," ObjShare(UCR._InputHandler.InputEvent.Bind(UCR._InputHandler)) ")`n" UCR._InputThreadScript)
 			While !this._InputThread.ahkgetvar.autoexecute_done
 				Sleep 10 ; wait until variable has been set.
-			OutputDebug % "UCR| Input Thread for thread #" this.id " ( " this.Name " ) has started"
+			;OutputDebug % "UCR| Input Thread for thread #" this.id " ( " this.Name " ) has started"
 			; Get thread-safe boundfunc object for thread's SetHotkeyState
 			this._SetHotkeyState := ObjShare(this._InputThread.ahkgetvar("_InterfaceSetHotkeyState"))
 			this._SetButtonBinding := ObjShare(this._InputThread.ahkgetvar("_InterfaceSetButtonBinding"))

--- a/UCR.ahk
+++ b/UCR.ahk
@@ -177,26 +177,39 @@ Class UCRMain {
 	}
 	
 	; We wish to change profile. This may happen due to user input, or application changing
+	; Save param can be set to 0 to not save when changing profile ...
+	; ... eg so that when _LoadSettings() calls ChangeProfile, we do not save while loading.
 	ChangeProfile(id, save := 1){
 		if (!ObjHasKey(this.Profiles, id))
 			return 0
 		newprofile := this.Profiles[id]
 		OutputDebug % "Changing Profile from " this.CurrentProfile.Name " to: " newprofile.Name
+		; Check if there is currently an active profile
 		if (IsObject(this.CurrentProfile)){
+			; Do nothing if we are changing to the currently active profile
 			if (id = this.CurrentProfile.id)
 				return 1
+			; Make the Gui of the current profile invisible
 			this.CurrentProfile._Hide()
+			; De-Activate the current profile if it is not global
 			if (!this.CurrentProfile._IsGlobal)
 				this.CurrentProfile._DeActivate()
 		}
 		
+		; Change current profile to new profile
 		this.CurrentProfile := this.Profiles[id]
 		
+		; Update Gui to reflect new current profile
 		this.UpdateCurrentProfileReadout()
 		this._ProfileToolbox.SelectProfileByID(id)
 		
+		; Start running new profile
 		this.CurrentProfile._Activate()
+		
+		; Make the new profile's Gui visible
 		this.CurrentProfile._Show()
+		
+		; Save settings
 		if (save){
 			this._ProfileChanged(this.CurrentProfile)
 		}

--- a/UCR.ahk
+++ b/UCR.ahk
@@ -198,10 +198,9 @@ Class UCRMain {
 			; De-Activate the current profile if it is not global or Linked
 			if (!this.CurrentProfile._IsGlobal){
 				this.CurrentProfile._DeActivate()
-				; If the current profile is not a "Linked Profile" of the new profile, then stop it's Input Thread.
-				if (!ObjHasKey(newprofile._LinkedProfiles, this.CurrentProfile.id)){
+				; If the current profile is not a "Linked Profile" of the new profile or the Global profile, then stop it's Input Thread.
+				if (! (ObjHasKey(this.Profiles[1]._LinkedProfiles, this.CurrentProfile.id) || ObjHasKey(newprofile._LinkedProfiles, this.CurrentProfile.id)))
 					this.CurrentProfile._StopInputThread()
-				}
 			}
 		}
 		

--- a/UCR.ahk
+++ b/UCR.ahk
@@ -214,7 +214,9 @@ Class UCRMain {
 			}
 			
 			; Stop the InputThread of any profiles that are no longer linked
-			for profile, state in this._ActiveInputThreads {
+			; _ActiveInputThreads may be modified by this operation, so iterate a cloned version.
+			activethreads := this._ActiveInputThreads.clone()
+			for profile, state in activethreads {
 				if (! (profile == 1 || ObjHasKey(this.Profiles[1]._LinkedProfiles, profile) || ObjHasKey(newprofile._LinkedProfiles, profile))){
 					this._SetProfileInputThreadState(profile,0)
 				}

--- a/UCR.ahk
+++ b/UCR.ahk
@@ -9,7 +9,7 @@ return
 
 ; ======================================================================== MAIN CLASS ===============================================================
 Class UCRMain {
-	Version := "0.0.7"				; The version of the main application
+	Version := "0.0.8"				; The version of the main application
 	SettingsVersion := "0.0.2"		; The version of the settings file format
 	_StateNames := {0: "Normal", 1: "InputBind", 2: "GameBind"}
 	_State := {Normal: 0, InputBind: 1, GameBind: 2}

--- a/UCR.ahk
+++ b/UCR.ahk
@@ -182,6 +182,8 @@ Class UCRMain {
 		this.CurrentProfile._AddPlugin()
 	}
 	
+	; Turns on or off the "Input Thread" for a given profile
+	; Also maintains a list of the active threads, so they can be managed on profile change
 	_SetProfileInputThreadState(profile, state){
 		if (state){
 			this._ActiveInputThreads[profile] := 1

--- a/UCR.ahk
+++ b/UCR.ahk
@@ -1290,6 +1290,7 @@ class _BindModeHandler {
 ; The Profile's is parent to 0 or more plugins, which are each an instance of the _Plugin class.
 ; The Gui of each plugin appears inside the Gui of this profile.
 Class _Profile {
+	ID := ""				; Unique ID. Set in Ctor
 	Name := ""
 	ParentProfile := 0
 	Plugins := {}

--- a/UCR.ahk
+++ b/UCR.ahk
@@ -1314,6 +1314,11 @@ Class _Profile {
 			this._SetButtonBinding := ObjShare(this._InputThread.ahkgetvar("_InterfaceSetButtonBinding"))
 			this._SetAxisBinding := ObjShare(this._InputThread.ahkgetvar("_InterfaceSetAxisBinding"))
 			this._SetDeltaBinding := ObjShare(this._InputThread.ahkgetvar("_InterfaceSetDeltaBinding"))
+			; Load bindings
+			Loop % this.PluginOrder.length() {
+				plugin := this.Plugins[this.PluginOrder[A_Index]]
+				plugin._RequestBinding()
+			}
 		}
 	}
 	
@@ -1354,10 +1359,6 @@ Class _Profile {
 	_Activate(){
 		if (!this._InputThread){
 			this._StartInputThread()
-			Loop % this.PluginOrder.length() {
-				plugin := this.Plugins[this.PluginOrder[A_Index]]
-				plugin._RequestBinding()
-			}
 		}
 		this._SetHotkeyState(1)
 		; Fire Activate on each plugin

--- a/UCR.ahk
+++ b/UCR.ahk
@@ -184,7 +184,7 @@ Class UCRMain {
 	
 	_SetProfileInputThreadState(profile, state){
 		if (state){
-			this._ActiveInputThreads.Delete(profile)
+			this._ActiveInputThreads.Delete(profile)	; Remove key entirely for "off"
 			this.Profiles[profile]._StartInputThread()
 		} else {
 			this._ActiveInputThreads[profile] := 1
@@ -207,14 +207,19 @@ Class UCRMain {
 				return 1
 			; Make the Gui of the current profile invisible
 			this.CurrentProfile._Hide()
-			; De-Activate the current profile if it is not global or Linked
+			
+			; De-Activate the old profile if it is not Global
 			if (!this.CurrentProfile._IsGlobal){
 				this.CurrentProfile._DeActivate()
-				; If the current profile is not a "Linked Profile" of the new profile or the Global profile, then stop it's Input Thread.
-				if (! (ObjHasKey(this.Profiles[1]._LinkedProfiles, this.CurrentProfile.id) || ObjHasKey(newprofile._LinkedProfiles, this.CurrentProfile.id)))
-					;this.CurrentProfile._StopInputThread()
-					this._SetProfileInputThreadState(this.CurrentProfile.id,0)
 			}
+			
+			; Stop the InputThread of any profiles that are no longer linked
+			for profile, state in this._ActiveInputThreads {
+				if (! (profile == 1 || ObjHasKey(this.Profiles[1]._LinkedProfiles, profile) || ObjHasKey(newprofile._LinkedProfiles, profile))){
+					this._SetProfileInputThreadState(profile,0)
+				}
+			}
+			
 		}
 		
 		; Change current profile to new profile

--- a/UCR.ahk
+++ b/UCR.ahk
@@ -1273,6 +1273,10 @@ Class _Profile {
 			ahkthread_free(this._InputThread)
 			this._InputThread := 0
 		}
+		this._SetHotkeyState := 0
+		this._SetButtonBinding := 0
+		this._SetAxisBinding := 0
+		this._SetDeltaBinding := 0
 	}
 	
 	__Delete(){

--- a/UCR.ahk
+++ b/UCR.ahk
@@ -30,11 +30,15 @@ Class UCRMain {
 	CurrentPos := {x: "", y: ""}										; The current position of the app.
 	_ProfileTreeChangeSubscriptions := {}	; An hwnd-indexed array of callbacks for things that wish to be notified if the profile tree changes
 	_InputActivitySubscriptions := {}
+	_InputThreadScript := ""		; Set in Ctor
 	
 	__New(){
 		global UCR := this			; Set super-global UCR to point to class instance
 		Gui +HwndHwnd
 		this.hwnd := hwnd
+		
+		FileRead, Script, % A_ScriptDir "\Threads\ProfileInputThread.ahk"
+		this._InputThreadScript := Script	; Cache script for profile InputThreads
 		
 		str := A_ScriptName
 		if (A_IsCompiled)
@@ -1279,10 +1283,10 @@ Class _Profile {
 	_StartInputThread(){
 		if (this._InputThread == 0){
 			OutputDebug % "UCR| Starting Input Thread for thread #" this.id " ( " this.Name " )"
-			FileRead, Script, % A_ScriptDir "\Threads\ProfileInputThread.ahk"
 			this._InputThread := AhkThread("InputThread := new _InputThread(" ObjShare(UCR._InputHandler.InputEvent.Bind(UCR._InputHandler)) ")`n" Script)
 			While !this._InputThread.ahkgetvar.autoexecute_done
-				Sleep 50 ; wait until variable has been set.
+				Sleep 10 ; wait until variable has been set.
+			OutputDebug % "UCR| Input Thread for thread #" this.id " ( " this.Name " ) has started"
 			; Get thread-safe boundfunc object for thread's SetHotkeyState
 			this._SetHotkeyState := ObjShare(this._InputThread.ahkgetvar("_InterfaceSetHotkeyState"))
 			this._SetButtonBinding := ObjShare(this._InputThread.ahkgetvar("_InterfaceSetButtonBinding"))
@@ -1496,7 +1500,7 @@ Class _Profile {
 	}
 
 	_PluginChanged(plugin){
-		OutputDebug % "UCR| Profile " this.Name " calling UCR._ProfileChanged"
+		OutputDebug % "UCR| Profile " this.Name " called UCR._ProfileChanged()"
 		UCR._ProfileChanged(this)
 	}
 }

--- a/UCR.ahk
+++ b/UCR.ahk
@@ -1283,7 +1283,7 @@ Class _Profile {
 	_StartInputThread(){
 		if (this._InputThread == 0){
 			OutputDebug % "UCR| Starting Input Thread for thread #" this.id " ( " this.Name " )"
-			this._InputThread := AhkThread("InputThread := new _InputThread(" ObjShare(UCR._InputHandler.InputEvent.Bind(UCR._InputHandler)) ")`n" Script)
+			this._InputThread := AhkThread("InputThread := new _InputThread(" this.id "," ObjShare(UCR._InputHandler.InputEvent.Bind(UCR._InputHandler)) ")`n" UCR._InputThreadScript)
 			While !this._InputThread.ahkgetvar.autoexecute_done
 				Sleep 10 ; wait until variable has been set.
 			OutputDebug % "UCR| Input Thread for thread #" this.id " ( " this.Name " ) has started"

--- a/UCR.ahk
+++ b/UCR.ahk
@@ -1266,6 +1266,7 @@ Class _Profile {
 	_IsGlobal := 0
 	_InputThread := 0
 	_LinkedProfiles := {}	; Profiles with which this one is associated
+	__LinkedProfiles := {}	; Table of plugin to profile links, used to build _LinkedProfiles
 	
 	__New(id, name, parent){
 		static fn
@@ -1277,6 +1278,28 @@ Class _Profile {
 		}
 		;this._StartInputThread()
 		this._CreateGui()
+	}
+	
+	; Updates the list of "Linked" profiles...
+	; plugin = plugin altering it's link status with a profile
+	; profile = profile that the plugin is altering it's relation to
+	; state = new state of the plugin's relation to that profile
+	UpdateLinkedProfiles(plugin, profile, state){
+		; Update plugin -> profile links
+		if (!IsObject(this.__LinkedProfiles[plugin])){
+			this.__LinkedProfiles[plugin] := {}
+		}
+		this.__LinkedProfiles[plugin, profile] := state
+		
+		; Rebuild profile -> profile links
+		this._LinkedProfiles := {}
+		for plug, profs in this.__LinkedProfiles {
+			for prof, linked in profs {
+				if (linked) {
+					this._LinkedProfiles[prof] := 1
+				}
+			}
+		}
 	}
 	
 	; Starts the "Input Thread" which handles detection of input for this profile

--- a/UCR.ahk
+++ b/UCR.ahk
@@ -77,6 +77,7 @@ Class UCRMain {
 		; Now we have settings from disk, move the window to it's last position and size
 		this._ShowGui()
 		
+		this.Profiles.1._StartInputThread()
 		this.Profiles.1._Activate()
 		this.ChangeProfile(p, 0)
 
@@ -212,6 +213,7 @@ Class UCRMain {
 		this._ProfileToolbox.SelectProfileByID(id)
 		
 		; Start running new profile
+		this.CurrentProfile._StartInputThread()
 		this.CurrentProfile._Activate()
 		
 		; Make the new profile's Gui visible
@@ -1357,9 +1359,9 @@ Class _Profile {
 	
 	; The profile became active
 	_Activate(){
-		if (!this._InputThread){
-			this._StartInputThread()
-		}
+		;~ if (!this._InputThread){
+			;~ this._StartInputThread()
+		;~ }
 		this._SetHotkeyState(1)
 		; Fire Activate on each plugin
 		Loop % this.PluginOrder.length() {

--- a/UCR.ahk
+++ b/UCR.ahk
@@ -199,12 +199,12 @@ Class UCRMain {
 		if (!ObjHasKey(this.Profiles, id))
 			return 0
 		newprofile := this.Profiles[id]
-		OutputDebug % "UCR| Changing Profile from " this.CurrentProfile.Name " to: " newprofile.Name
 		; Check if there is currently an active profile
 		if (IsObject(this.CurrentProfile)){
 			; Do nothing if we are changing to the currently active profile
 			if (id = this.CurrentProfile.id)
 				return 1
+			OutputDebug % "UCR| Changing Profile from " this.CurrentProfile.Name " to: " newprofile.Name
 			; Make the Gui of the current profile invisible
 			this.CurrentProfile._Hide()
 			
@@ -219,6 +219,8 @@ Class UCRMain {
 					this._SetProfileInputThreadState(profile,0)
 				}
 			}
+		} else {
+			OutputDebug % "UCR| Changing Profile for first time to: " newprofile.Name
 		}
 		
 		; Change current profile to new profile
@@ -745,7 +747,11 @@ class _ProfileToolbox extends _ProfileSelect {
 	
 	TV_Event(){
 		if (A_GuiEvent == "Normal" || A_GuiEvent == "S"){
-			UCR.ChangeProfile(this.LvHandleToProfileId[A_EventInfo])
+			newprofile := this.LvHandleToProfileId[A_EventInfo]
+			; ToDo: This seems to trigger twice when changing profile to the last child.
+			; Not a big issue as changing to current profile is ignored by ChangeProfile()
+			;OutputDebug % "UCR| TV Change profile: " newprofile
+			UCR.ChangeProfile(newprofile)
 		} else if (A_GuiEvent == "D"){
 			this.hDragitem := A_EventInfo
 			this.Treeview_BeginDrag()

--- a/UCR.ahk
+++ b/UCR.ahk
@@ -1391,8 +1391,8 @@ Class _Profile {
 	; The profile became active
 	_Activate(){
 		if (this._InputThread == 0){
-			MsgBox % "Error. Tried to Activate profile # " this.id " (" this.name " ) without an active Input Thread"
-			return
+			OutputDebug % "UCR| WARNING: Tried to Activate profile # " this.id " (" this.name " ) without an active Input Thread"
+			UCR._SetProfileInputThreadState(this.id,1)
 		}
 		this._SetHotkeyState(1)
 		; Fire Activate on each plugin

--- a/UCR.ahk
+++ b/UCR.ahk
@@ -225,7 +225,7 @@ Class UCRMain {
 		this._ProfileToolbox.SelectProfileByID(id)
 		
 		; Start running new profile
-		this.CurrentProfile._StartInputThread()
+		this._SetProfileInputThreadState(id,1)
 		this.CurrentProfile._Activate()
 		
 		; Make the new profile's Gui visible


### PR DESCRIPTION
Functionality ro allow Profile's InputThreads to dynamically start and stop, with a mechanism to allow InputThreads that are likely to be needed quickly (eg because the current profile has a profile switcher plugin that points to that profile) can be kept running