### PR TITLE
Detect joysticks with JoyAxes rather than JoyInfo. Fixes evilC/UCR#130

### DIFF
--- a/Classes/GuiControls/IOClasses/AHK.ahk
+++ b/Classes/GuiControls/IOClasses/AHK.ahk
@@ -201,7 +201,7 @@ class AHK_JoyAxis_Input extends _UCR.Classes.IOClasses.IOClassBase {
 		}
 		Loop 8 {
 			stick := A_Index
-			ji := (GetKeyState(stick "JoyInfo"))
+			ji := (GetKeyState(stick "JoyAxes"))
 			this._StickMenus[A_Index].SetEnableState(ji)
 			;if (UCR.UserSettings.GuiControls.ShowJoystickNames){
 			;	name := " (" DllCall("JoystickOEMName\joystick_OEM_name", double,A_Index, "CDECL AStr") ")"

--- a/Threads/ProfileInputThread.ahk
+++ b/Threads/ProfileInputThread.ahk
@@ -272,7 +272,7 @@ Class _InputThread {
 			if (bo.Binding[1]){
 				keyname := this.BuildHotkeyString(bo)
 				fn := this.KeyEvent.Bind(this, ControlGUID, 1)
-				if (GetKeyState(bo.DeviceID "JoyInfo"))
+				if (GetKeyState(bo.DeviceID "JoyAxes")) 
 					try {
 						hotkey, % keyname, % fn, On
 					}
@@ -407,7 +407,7 @@ Class _InputThread {
 			if (this.TimerWanted && this.DetectionState && !this.TimerRunning){
 				; Pre-cache connected sticks, as polling disconnected sticks takes lots of CPU
 				Loop 8 {
-					this.ConnectedSticks[A_Index] := GetKeyState(A_Index "JoyInfo")
+					this.ConnectedSticks[A_Index] := (GetKeyState(A_Index "JoyAxes") > 0)
 				}
 				SetTimer, % fn, 10
 				this.TimerRunning := 1


### PR DESCRIPTION
JoyInfo would not include a joystick with only X and Y axes. Therefore we'll have to use JoyAxes in order to detect connected joysticks, which will report 0 axes if a joystick is not connected.

JoyInfo: Provides a string consisting of zero or more of the following letters to indicate the joystick's capabilities: Z (has Z axis), R (has R axis), U (has U axis), V (has V axis), P (has POV control), D (the POV control has a limited number of discrete/distinct settings), C (the POV control is continous/fine). Example string: ZRUVPD